### PR TITLE
feat(UI Builder): Add support to change results layout

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -19,7 +19,7 @@ import get from 'lodash.get';
 import { string, bool } from 'prop-types';
 import strip from 'striptags';
 import Truncate from 'react-truncate';
-import { Card, Collapse, Button, Icon, Affix, Tooltip } from 'antd';
+import { Card, Collapse, Button, Icon, Affix, Tooltip, List } from 'antd';
 import { mediaMax } from '../utils/media';
 import Suggestions from './Suggestions';
 import {
@@ -48,14 +48,14 @@ const loaderStyle = css`
     position: relative;
 `;
 
-const reactiveListCls= (toggleFilters, theme) =>css`
+const reactiveListCls = (toggleFilters, theme) => css`
     .custom-no-results {
         display: flex;
         justify-content: center;
         padding: 25px 0;
     }
     .custom-pagination {
-        max-width:none;
+        max-width: none;
         padding-bottom: 50px;
         a {
             border-radius: 2px;
@@ -63,8 +63,8 @@ const reactiveListCls= (toggleFilters, theme) =>css`
         a.active {
             color: ${get(theme, 'colors.textColor')};
         }
-        @media(max-width: 768px){
-            display: ${toggleFilters ? 'none' : 'block'}
+        @media (max-width: 768px) {
+            display: ${toggleFilters ? 'none' : 'block'};
         }
     }
     .custom-powered-by {
@@ -76,11 +76,7 @@ const reactiveListCls= (toggleFilters, theme) =>css`
         padding: 18px;
         height: 60px;
         ${mediaMax.medium} {
-            display: ${
-                toggleFilters
-                    ? 'none'
-                    : 'grid'
-            };
+            display: ${toggleFilters ? 'none' : 'grid'};
             justify-content: center;
         }
     }
@@ -89,19 +85,14 @@ const reactiveListCls= (toggleFilters, theme) =>css`
         grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
         grid-gap: 10px;
         ${mediaMax.medium} {
-            grid-template-columns:
-                repeat(auto-fit, minmax(200px, 1fr));
-            display: ${
-                toggleFilters
-                    ? 'none'
-                    : 'grid'
-            };
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            display: ${toggleFilters ? 'none' : 'grid'};
         }
         ${mediaMax.small} {
             grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
         }
     }
-`
+`;
 
 export const cardStyles = ({ textColor, titleColor, primaryColor }) => css`
     position: relative;
@@ -143,7 +134,6 @@ export const cardStyles = ({ textColor, titleColor, primaryColor }) => css`
         }
     }
 
-
     .ant-card-cover img {
         object-fit: contain;
         height: 100%;
@@ -181,6 +171,46 @@ export const cardStyles = ({ textColor, titleColor, primaryColor }) => css`
     @media (max-width: 768px) {
         .ant-card-cover img {
             object-fit: contain;
+        }
+    }
+`;
+
+export const listStyles = ({ titleColor, primaryColor }) => css`
+    position: relative;
+    overflow: hidden;
+    padding: 5px 20px;
+    width: 100%;
+    height: 100%;
+    .product-button {
+        top: -50%;
+        position: absolute;
+        background: ${primaryColor} !important;
+        border: 0;
+        box-shadow: 0 2px 4px ${titleColor}33;
+        left: 50%;
+        transform: translateX(-50%);
+        transition: all ease 0.2s;
+    }
+
+    ::before {
+        content: '';
+        width: 100%;
+        height: 0vh;
+        background: ${primaryColor}00 !important;
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: block;
+        transition: all ease 0.4s;
+    }
+    &:hover {
+        .product-button {
+            top: 45%;
+        }
+        ::before {
+            width: 100%;
+            height: 100%;
+            background: ${primaryColor}1a !important;
         }
     }
 `;
@@ -267,6 +297,11 @@ class Search extends Component {
             'exportSettings.type',
             defaultPreferences.exportType,
         );
+        this.layout = get(
+            this.preferences,
+            'resultSettings.layout',
+            defaultPreferences.resultSettings.layout,
+        );
     }
 
     async componentDidMount() {
@@ -275,8 +310,10 @@ class Search extends Component {
             const inputRef = get(searchRef, 'current._inputRef', null);
 
             if (inputRef) {
-                const param = new URLSearchParams(window.location.search).get('q')
-                if(!param) {
+                const param = new URLSearchParams(window.location.search).get(
+                    'q',
+                );
+                if (!param) {
                     inputRef.focus();
                 }
             }
@@ -314,7 +351,7 @@ class Search extends Component {
     updateDimensions = () => {
         this.setState({
             isMobile: window.innerWidth < 768,
-            toggleFilters: false
+            toggleFilters: false,
         });
     };
 
@@ -730,7 +767,8 @@ class Search extends Component {
                     popularSuggestions,
                     downshiftProps,
                 }) => {
-                    return downshiftProps.isOpen && (popularSuggestions.length || data.length) ? (
+                    return downshiftProps.isOpen &&
+                        (popularSuggestions.length || data.length) ? (
                         <Suggestions
                             themeType={this.themeType}
                             fields={get(this.searchSettings, 'fields', {})}
@@ -757,7 +795,7 @@ class Search extends Component {
                             isPreview={isPreview}
                             popularSuggestions={popularSuggestions}
                         />
-                    ) : null
+                    ) : null;
                 }}
                 {...this.searchSettings.rsConfig}
                 {...categorySearchProps}
@@ -792,23 +830,35 @@ class Search extends Component {
                 appbaseConfig={{
                     recordAnalytics: true,
                 }}
-                setSearchParams={isPreview ? () => {} : (url) => {
-                    window.history.pushState({ path: url }, '', url);
-                    return url
-                }}
-                getSearchParams={isPreview ? () => {} : () => {
-                    const params = new URLSearchParams(window.location.search)
-                    const searchParam = params.get('q');
-                    if(searchParam) {
-                        try {
-                            JSON.parse(searchParam)
-                        } catch(e) {
-                            params.set('q', JSON.stringify(params.get('q')))
-                        }
-
-                    }
-                    return params.toString()
-                }}
+                setSearchParams={
+                    isPreview
+                        ? () => {}
+                        : (url) => {
+                              window.history.pushState({ path: url }, '', url);
+                              return url;
+                          }
+                }
+                getSearchParams={
+                    isPreview
+                        ? () => {}
+                        : () => {
+                              const params = new URLSearchParams(
+                                  window.location.search,
+                              );
+                              const searchParam = params.get('q');
+                              if (searchParam) {
+                                  try {
+                                      JSON.parse(searchParam);
+                                  } catch (e) {
+                                      params.set(
+                                          'q',
+                                          JSON.stringify(params.get('q')),
+                                      );
+                                  }
+                              }
+                              return params.toString();
+                          }
+                }
             >
                 <Global
                     styles={css`
@@ -1190,263 +1240,481 @@ class Search extends Component {
                                         : null
                                 }
                             />
-                            {!toggleFilters && (
-                                <ReactiveList
-                                    componentId="results"
-                                    dataField="title"
-                                    ref={resultRef}
-                                    defaultQuery={() => ({
-                                        track_total_hits: true,
-                                    })}
-                                    renderNoResults={() => (
-                                        <div
-                                            style={{ textAlign: 'right' }}
-                                            // eslint-disable-next-line
-                                            dangerouslySetInnerHTML={{
-                                                __html: get(
-                                                    this.resultSettings,
-                                                    'customMessages.noResults',
-                                                    'No Results Found!',
-                                                ),
-                                            }}
-                                        />
-                                    )}
-                                    renderResultStats={({
-                                        numberOfResults,
-                                        time,
-                                    }) => (
-                                        <div
-                                            // eslint-disable-next-line
-                                            dangerouslySetInnerHTML={{
-                                                __html: get(
-                                                    this.resultSettings,
-                                                    'customMessages.resultStats',
-                                                    '[count] products found in [time] ms',
-                                                )
-                                                    .replace(
-                                                        '[count]',
-                                                        numberOfResults,
+                            {!toggleFilters &&
+                                (this.layout === 'list' ? (
+                                    <ReactiveList
+                                        componentId="results"
+                                        dataField="title"
+                                        ref={resultRef}
+                                        defaultQuery={() => ({
+                                            track_total_hits: true,
+                                        })}
+                                        renderNoResults={() => (
+                                            <div
+                                                style={{ textAlign: 'right' }}
+                                                // eslint-disable-next-line
+                                                dangerouslySetInnerHTML={{
+                                                    __html: get(
+                                                        this.resultSettings,
+                                                        'customMessages.noResults',
+                                                        'No Results Found!',
+                                                    ),
+                                                }}
+                                            />
+                                        )}
+                                        renderResultStats={({
+                                            numberOfResults,
+                                            time,
+                                        }) => (
+                                            <div
+                                                // eslint-disable-next-line
+                                                dangerouslySetInnerHTML={{
+                                                    __html: get(
+                                                        this.resultSettings,
+                                                        'customMessages.resultStats',
+                                                        '[count] products found in [time] ms',
                                                     )
-                                                    .replace('[time]', time),
-                                            }}
-                                        />
-                                    )}
-                                    renderItem={(
-                                        { _id, variants, ...rest },
-                                        triggerClickAnalytics,
-                                    ) => {
-                                        const handle = isPreview
-                                            ? ''
-                                            : get(
-                                                  rest,
-                                                  get(
-                                                      this.resultSettings,
-                                                      'fields.handle',
-                                                  ),
-                                              );
-
-                                        const image = get(
-                                            rest,
-                                            get(
-                                                this.resultSettings,
-                                                'fields.image',
-                                            ),
-                                        );
-                                        const title = get(
-                                            rest,
-                                            get(
-                                                this.resultSettings,
-                                                'fields.title',
-                                            ),
-                                        );
-
-                                        const description = get(
-                                            rest,
-                                            get(
-                                                this.resultSettings,
-                                                'fields.description',
-                                            ),
-                                        );
-                                        const price = get(
-                                            rest,
-                                            get(
-                                                this.resultSettings,
-                                                'fields.price',
-                                            ),
-                                        );
-                                        const redirectToProduct =
-                                            !isPreview || handle;
-                                        return (
-                                            <a
-                                                onClick={triggerClickAnalytics}
-                                                href={
-                                                    redirectToProduct
-                                                        ? `/products/${handle}`
-                                                        : undefined
-                                                }
-                                                target="_blank"
-                                                rel="noreferrer noopener"
-                                                key={_id}
-                                                id={_id}
-                                            >
-                                                <Card
-                                                    hoverable={false}
-                                                    bordered={false}
-                                                    className="card"
-                                                    css={cardStyles({
-                                                        ...get(
-                                                            this.theme,
-                                                            'colors',
-                                                        ),
-                                                    })}
-                                                    cover={
-                                                        image && (
-                                                            <img
-                                                                src={image}
-                                                                width="100%"
-                                                                alt={title}
-                                                            />
+                                                        .replace(
+                                                            '[count]',
+                                                            numberOfResults,
                                                         )
-                                                    }
-                                                    style={{
-                                                        ...this.getFontFamily(),
-                                                        padding:
-                                                            this.themeType ===
-                                                            'minimal'
-                                                                ? '10px'
-                                                                : 0,
-                                                    }}
-                                                    bodyStyle={
-                                                        this.themeType ===
-                                                        'minimal'
-                                                            ? {
-                                                                  padding:
-                                                                      '15px 10px 10px',
-                                                              }
-                                                            : {}
-                                                    }
-                                                >
-                                                    <Meta
-                                                        title={
-                                                            <h3
-                                                                css={cardTitleStyles(
-                                                                    get(
-                                                                        this
-                                                                            .theme,
-                                                                        'colors',
-                                                                    ),
-                                                                )}
-                                                                style={
-                                                                    this
-                                                                        .themeType ===
-                                                                    'minimal'
-                                                                        ? {
-                                                                              fontWeight: 600,
-                                                                          }
-                                                                        : {}
+                                                        .replace(
+                                                            '[time]',
+                                                            time,
+                                                        ),
+                                                }}
+                                            />
+                                        )}
+                                        size={9}
+                                        infiniteScroll
+                                        render={({
+                                            data,
+                                            triggerClickAnalytics,
+                                        }) => {
+                                            return (
+                                                <List
+                                                    itemLayout="vertical"
+                                                    size="large"
+                                                    dataSource={data}
+                                                    renderItem={(item) => {
+                                                        const handle = isPreview
+                                                            ? ''
+                                                            : get(
+                                                                  item,
+                                                                  get(
+                                                                      this
+                                                                          .resultSettings,
+                                                                      'fields.handle',
+                                                                  ),
+                                                              );
+                                                        const redirectToProduct =
+                                                            !isPreview ||
+                                                            handle;
+                                                        return (
+                                                            <a
+                                                                href={
+                                                                    redirectToProduct
+                                                                        ? `/products/${handle}`
+                                                                        : undefined
                                                                 }
-                                                                // eslint-disable-next-line
-                                                                dangerouslySetInnerHTML={{
-                                                                    __html: title,
-                                                                }}
-                                                            />
-                                                        }
-                                                        description={
-                                                            description &&
-                                                                this.themeType ===
-                                                                'classic' ? (
-                                                                <Truncate
-                                                                    lines={
-                                                                        4
+                                                                target="_blank"
+                                                                rel="noreferrer noopener"
+                                                                key={item._id}
+                                                            >
+                                                                <List.Item
+                                                                    id={
+                                                                        item._id
                                                                     }
-                                                                    ellipsis={
-                                                                        <span>
-                                                                            ...
-                                                                        </span>
+                                                                    onClick={
+                                                                        triggerClickAnalytics
+                                                                    }
+                                                                    css={listStyles(
+                                                                        {
+                                                                            ...get(
+                                                                                this
+                                                                                    .theme,
+                                                                                'colors',
+                                                                            ),
+                                                                        },
+                                                                    )}
+                                                                    extra={
+                                                                        <img
+                                                                            src={
+                                                                                item
+                                                                                    .image
+                                                                                    .src
+                                                                            }
+                                                                            width={
+                                                                                150
+                                                                            }
+                                                                            alt={
+                                                                                item.title
+                                                                            }
+                                                                        />
                                                                     }
                                                                 >
-                                                                    {strip(
-                                                                        description,
-                                                                    )}
-                                                                </Truncate>
-                                                            ) : null
+                                                                    <List.Item.Meta
+                                                                        title={
+                                                                            item.title
+                                                                        }
+                                                                        description={
+                                                                            item.body_html &&
+                                                                            this
+                                                                                .themeType ===
+                                                                                'classic' ? (
+                                                                                <Truncate
+                                                                                    lines={
+                                                                                        4
+                                                                                    }
+                                                                                    ellipsis={
+                                                                                        <span>
+                                                                                            ...
+                                                                                        </span>
+                                                                                    }
+                                                                                >
+                                                                                    {strip(
+                                                                                        item.body_html,
+                                                                                    )}
+                                                                                </Truncate>
+                                                                            ) : null
+                                                                        }
+                                                                    />
+                                                                    {item.variants ||
+                                                                    item.price ? (
+                                                                        <div>
+                                                                            <h3
+                                                                                style={{
+                                                                                    fontWeight: 500,
+                                                                                    fontSize:
+                                                                                        '1rem',
+                                                                                    marginTop: 6,
+                                                                                    color:
+                                                                                        this
+                                                                                            .themeType ===
+                                                                                        'minimal'
+                                                                                            ? get(
+                                                                                                  this
+                                                                                                      .theme,
+                                                                                                  'colors.textColor',
+                                                                                              )
+                                                                                            : get(
+                                                                                                  this
+                                                                                                      .theme,
+                                                                                                  'colors.titleColor',
+                                                                                              ),
+                                                                                }}
+                                                                            >
+                                                                                {`${
+                                                                                    this
+                                                                                        .currency
+                                                                                } ${
+                                                                                    item.variants
+                                                                                        ? get(
+                                                                                              item
+                                                                                                  .variants[0],
+                                                                                              'price',
+                                                                                              '',
+                                                                                          )
+                                                                                        : item.price
+                                                                                }`}
+                                                                            </h3>
+                                                                        </div>
+                                                                    ) : null}
+                                                                    {redirectToProduct ? (
+                                                                        <Button
+                                                                            type="primary"
+                                                                            size="large"
+                                                                            className="product-button"
+                                                                        >
+                                                                            <Icon type="eye" />
+                                                                            View
+                                                                            Product
+                                                                        </Button>
+                                                                    ) : null}
+                                                                </List.Item>
+                                                            </a>
+                                                        );
+                                                    }}
+                                                />
+                                            );
+                                        }}
+                                        react={{
+                                            and: [
+                                                'filter_by_product',
+                                                ...getReactDependenciesFromPreferences(
+                                                    this.preferences,
+                                                    'result',
+                                                ),
+                                            ],
+                                        }}
+                                    />
+                                ) : (
+                                    <ReactiveList
+                                        componentId="results"
+                                        dataField="title"
+                                        ref={resultRef}
+                                        defaultQuery={() => ({
+                                            track_total_hits: true,
+                                        })}
+                                        renderNoResults={() => (
+                                            <div
+                                                style={{ textAlign: 'right' }}
+                                                // eslint-disable-next-line
+                                                dangerouslySetInnerHTML={{
+                                                    __html: get(
+                                                        this.resultSettings,
+                                                        'customMessages.noResults',
+                                                        'No Results Found!',
+                                                    ),
+                                                }}
+                                            />
+                                        )}
+                                        renderResultStats={({
+                                            numberOfResults,
+                                            time,
+                                        }) => (
+                                            <div
+                                                // eslint-disable-next-line
+                                                dangerouslySetInnerHTML={{
+                                                    __html: get(
+                                                        this.resultSettings,
+                                                        'customMessages.resultStats',
+                                                        '[count] products found in [time] ms',
+                                                    )
+                                                        .replace(
+                                                            '[count]',
+                                                            numberOfResults,
+                                                        )
+                                                        .replace(
+                                                            '[time]',
+                                                            time,
+                                                        ),
+                                                }}
+                                            />
+                                        )}
+                                        renderItem={(
+                                            { _id, variants, ...rest },
+                                            triggerClickAnalytics,
+                                        ) => {
+                                            const handle = isPreview
+                                                ? ''
+                                                : get(
+                                                      rest,
+                                                      get(
+                                                          this.resultSettings,
+                                                          'fields.handle',
+                                                      ),
+                                                  );
+
+                                            const image = get(
+                                                rest,
+                                                get(
+                                                    this.resultSettings,
+                                                    'fields.image',
+                                                ),
+                                            );
+                                            const title = get(
+                                                rest,
+                                                get(
+                                                    this.resultSettings,
+                                                    'fields.title',
+                                                ),
+                                            );
+
+                                            const description = get(
+                                                rest,
+                                                get(
+                                                    this.resultSettings,
+                                                    'fields.description',
+                                                ),
+                                            );
+                                            const price = get(
+                                                rest,
+                                                get(
+                                                    this.resultSettings,
+                                                    'fields.price',
+                                                ),
+                                            );
+                                            const redirectToProduct =
+                                                !isPreview || handle;
+                                            return (
+                                                <a
+                                                    onClick={
+                                                        triggerClickAnalytics
+                                                    }
+                                                    href={
+                                                        redirectToProduct
+                                                            ? `/products/${handle}`
+                                                            : undefined
+                                                    }
+                                                    target="_blank"
+                                                    rel="noreferrer noopener"
+                                                    key={_id}
+                                                    id={_id}
+                                                >
+                                                    <Card
+                                                        hoverable={false}
+                                                        bordered={false}
+                                                        className="card"
+                                                        css={cardStyles({
+                                                            ...get(
+                                                                this.theme,
+                                                                'colors',
+                                                            ),
+                                                        })}
+                                                        cover={
+                                                            image && (
+                                                                <img
+                                                                    src={image}
+                                                                    width="100%"
+                                                                    alt={title}
+                                                                />
+                                                            )
                                                         }
-                                                    />
-                                                    {variants || price ? (
-                                                        <div>
-                                                            <h3
-                                                                style={{
-                                                                    fontWeight: 500,
-                                                                    fontSize:
-                                                                        '1rem',
-                                                                    marginTop: 6,
-                                                                    color:
+                                                        style={{
+                                                            ...this.getFontFamily(),
+                                                            padding:
+                                                                this
+                                                                    .themeType ===
+                                                                'minimal'
+                                                                    ? '10px'
+                                                                    : 0,
+                                                        }}
+                                                        bodyStyle={
+                                                            this.themeType ===
+                                                            'minimal'
+                                                                ? {
+                                                                      padding:
+                                                                          '15px 10px 10px',
+                                                                  }
+                                                                : {}
+                                                        }
+                                                    >
+                                                        <Meta
+                                                            title={
+                                                                <h3
+                                                                    css={cardTitleStyles(
+                                                                        get(
+                                                                            this
+                                                                                .theme,
+                                                                            'colors',
+                                                                        ),
+                                                                    )}
+                                                                    style={
                                                                         this
                                                                             .themeType ===
                                                                         'minimal'
+                                                                            ? {
+                                                                                  fontWeight: 600,
+                                                                              }
+                                                                            : {}
+                                                                    }
+                                                                    // eslint-disable-next-line
+                                                                    dangerouslySetInnerHTML={{
+                                                                        __html: title,
+                                                                    }}
+                                                                />
+                                                            }
+                                                            description={
+                                                                description &&
+                                                                this
+                                                                    .themeType ===
+                                                                    'classic' ? (
+                                                                    <Truncate
+                                                                        lines={
+                                                                            4
+                                                                        }
+                                                                        ellipsis={
+                                                                            <span>
+                                                                                ...
+                                                                            </span>
+                                                                        }
+                                                                    >
+                                                                        {strip(
+                                                                            description,
+                                                                        )}
+                                                                    </Truncate>
+                                                                ) : null
+                                                            }
+                                                        />
+                                                        {variants || price ? (
+                                                            <div>
+                                                                <h3
+                                                                    style={{
+                                                                        fontWeight: 500,
+                                                                        fontSize:
+                                                                            '1rem',
+                                                                        marginTop: 6,
+                                                                        color:
+                                                                            this
+                                                                                .themeType ===
+                                                                            'minimal'
+                                                                                ? get(
+                                                                                      this
+                                                                                          .theme,
+                                                                                      'colors.textColor',
+                                                                                  )
+                                                                                : get(
+                                                                                      this
+                                                                                          .theme,
+                                                                                      'colors.titleColor',
+                                                                                  ),
+                                                                    }}
+                                                                >
+                                                                    {`${
+                                                                        this
+                                                                            .currency
+                                                                    } ${
+                                                                        variants
                                                                             ? get(
-                                                                                  this
-                                                                                      .theme,
-                                                                                  'colors.textColor',
+                                                                                  variants[0],
+                                                                                  'price',
+                                                                                  '',
                                                                               )
-                                                                            : get(
-                                                                                  this
-                                                                                      .theme,
-                                                                                  'colors.titleColor',
-                                                                              ),
-                                                                }}
-                                                            >
-                                                                {`${
-                                                                    this
-                                                                        .currency
-                                                                } ${
-                                                                    variants
-                                                                        ? get(
-                                                                              variants[0],
-                                                                              'price',
-                                                                              '',
-                                                                          )
-                                                                        : price
-                                                                }`}
-                                                            </h3>
-                                                        </div>
-                                                    ) : null}
+                                                                            : price
+                                                                    }`}
+                                                                </h3>
+                                                            </div>
+                                                        ) : null}
 
-                                                    {redirectToProduct ? (
-                                                        <Button
-                                                            type="primary"
-                                                            size="large"
-                                                            className="product-button"
-                                                        >
-                                                            <Icon type="eye" />
-                                                            View Product
-                                                        </Button>
-                                                    ) : null}
-                                                </Card>
-                                            </a>
-                                        );
-                                    }}
-                                    size={9}
-                                    innerClass={{
-                                        list: 'custom-result-list',
-                                        resultsInfo: 'custom-result-info',
-                                        poweredBy: 'custom-powered-by',
-                                        noResults: 'custom-no-results',
-                                        pagination: 'custom-pagination',
-                                    }}
-                                    {...this.resultSettings.rsConfig}
-                                    css={reactiveListCls(toggleFilters, this.theme)}
-                                    react={{
-                                        and: [
-                                            'filter_by_product',
-                                            ...getReactDependenciesFromPreferences(
-                                                this.preferences,
-                                                'result',
-                                            ),
-                                        ],
-                                    }}
-                                />
-                            )}
+                                                        {redirectToProduct ? (
+                                                            <Button
+                                                                type="primary"
+                                                                size="large"
+                                                                className="product-button"
+                                                            >
+                                                                <Icon type="eye" />
+                                                                View Product
+                                                            </Button>
+                                                        ) : null}
+                                                    </Card>
+                                                </a>
+                                            );
+                                        }}
+                                        size={9}
+                                        innerClass={{
+                                            list: 'custom-result-list',
+                                            resultsInfo: 'custom-result-info',
+                                            poweredBy: 'custom-powered-by',
+                                            noResults: 'custom-no-results',
+                                            pagination: 'custom-pagination',
+                                        }}
+                                        {...this.resultSettings.rsConfig}
+                                        css={reactiveListCls(
+                                            toggleFilters,
+                                            this.theme,
+                                        )}
+                                        react={{
+                                            and: [
+                                                'filter_by_product',
+                                                ...getReactDependenciesFromPreferences(
+                                                    this.preferences,
+                                                    'result',
+                                                ),
+                                            ],
+                                        }}
+                                    />
+                                ))}
                         </div>
                     </div>
                 </div>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -172,6 +172,7 @@ export const defaultPreferences = {
         rsConfig: {
             infiniteScroll: true,
         },
+        layout: 'card',
     },
     facetSettings: {
         globalSettings: {
@@ -303,24 +304,26 @@ export const getNoRecommendationMessage = (recommendationType) => {
         case RecommendationTypes.FEATURED_PRODUCTS:
             return (
                 <p>
-                    Please make sure that you have featured products and using an API credential that has read access to analytics. If the issue
-                    persists, then please contact us at{' '}
+                    Please make sure that you have featured products and using
+                    an API credential that has read access to analytics. If the
+                    issue persists, then please contact us at{' '}
                     <a href="mailto:support@appbase.io">support@appbase.io</a>.
                 </p>
             );
         case RecommendationTypes.MOST_POPULAR_PRODUCTS:
             return (
                 <p>
-                    Please make sure that you are using an API credential that has read access to analytics. If the issue
-                    persists, then please contact us at{' '}
+                    Please make sure that you are using an API credential that
+                    has read access to analytics. If the issue persists, then
+                    please contact us at{' '}
                     <a href="mailto:support@appbase.io">support@appbase.io</a>.
                 </p>
             );
         case RecommendationTypes.MOST_RECENT:
             return (
                 <p>
-                    Please make sure that the selected dataField is sortable. If the issue
-                    persists, then please contact us at{' '}
+                    Please make sure that the selected dataField is sortable. If
+                    the issue persists, then please contact us at{' '}
                     <a href="mailto:support@appbase.io">support@appbase.io</a>.
                 </p>
             );


### PR DESCRIPTION
Issue Type - Enhancement

Notion Link - https://www.notion.so/UI-Builder-Add-support-to-change-results-layout-95028ef9d5db407c8ad493dfd28165dd

Objectives -

- Currently, the results layout displays the card view. It should be possible to display a list-based layout.
- Layout must be configured by preferences.
- Default layout must be a card.

Description - 

- Layout support is added for results in Search which could be configured through the global preferences variable, by default the fallback layout is that of a card.

- To test we have to define a new property named layout in the resultSettings property of preferences.

- {
       resultSettings: {
           layout: 'list'
           // ...other properties
       }
   }


https://www.loom.com/share/8ebf08ec93af450f990c706cf85c7993